### PR TITLE
feat: update navigation dependencies and compose version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ kstore ="0.9.1"
 
 compose-plugin = "1.8.0-alpha03"
 composeNavigation="2.8.0-alpha13"
-androidxNavigationTest = "2.8.9" #for nav test
+androidxNavigationTest = "2.8.9"
 compose = "1.7.8"
 
 


### PR DESCRIPTION
- Updates the compose navigation version to `2.8.0-alpha13`.
- maintains `androidxNavigationTest` version `2.8.9`.
- updates compose version to `1.7.8`.